### PR TITLE
Add split transaction details to reason

### DIFF
--- a/src/app/components/AddExpenseModal.tsx
+++ b/src/app/components/AddExpenseModal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { useSession } from "next-auth/react"
 import Toast from "./Toast"
 
 interface User {
@@ -18,7 +19,13 @@ interface AddExpenseModalProps {
 // Local storage key for common users
 const COMMON_USERS_KEY = "splitwise_common_users"
 
+// Helper function to get first name from full name
+const getFirstName = (fullName: string): string => {
+  return fullName.split(' ')[0] || fullName
+}
+
 export default function AddExpenseModal({ isOpen, onClose, onSuccess }: AddExpenseModalProps) {
+  const { data: session } = useSession()
   const [amount, setAmount] = useState("")
   const [type] = useState<"lend" | "borrow">("lend") // Always lending since borrowers don't add transactions
   const [searchQuery, setSearchQuery] = useState("")
@@ -166,7 +173,9 @@ export default function AddExpenseModal({ isOpen, onClose, onSuccess }: AddExpen
         amount: Math.round(transactionAmount * 100) / 100, // Round to 2 decimal places
         type,
         otherUserId: user.id,
-        description: isSplit ? `${description} (Split: ${(Math.round(transactionAmount * 100) / 100).toFixed(2)} ETB each)` : description,
+        description: isSplit 
+          ? `${description} (Total: ${parseFloat(amount).toFixed(2)} ETB split among ${getFirstName(session?.user?.name || 'You')}, ${selectedUsers.map(u => getFirstName(u.name)).join(', ')})`
+          : description,
         receiptUrl: receiptUrl.trim() || undefined,
         isPayment,
       }))


### PR DESCRIPTION
Enhance the transaction description for split expenses to include the total amount and the first names of all participants.

---
<a href="https://cursor.com/background-agent?bcId=bc-69b96bbf-b77f-4e3c-a782-b4d8328d3ecb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-69b96bbf-b77f-4e3c-a782-b4d8328d3ecb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

